### PR TITLE
Remove redundant X-Auth headers from customer group post

### DIFF
--- a/reference/customers.v2.yml
+++ b/reference/customers.v2.yml
@@ -1959,16 +1959,6 @@ paths:
           type: string
           description: ''
           default: application/json
-        - name: X-Auth-Client
-          in: header
-          required: true
-          type: string
-          description: ''
-        - name: X-Auth-Token
-          in: header
-          required: true
-          type: string
-          description: ''
         - name: body
           in: body
           required: true


### PR DESCRIPTION
This PR removes redundant `X-Auth` headers from the customers v2 customer_group POST headers. Those are already added in as base headers for all REST API calls, so an explicit definition conflicts with code generation tools.